### PR TITLE
Refactor extract methods and add composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ api.where({name: 'John Doe'});
 
 #### `.withComposition(value)`
 
-Defines whether Reference fields should be resolved using composition.
+Defines whether nested documents should be resolved using composition. Defaults to `false`.
 
 ```js
 // Example

--- a/README.md
+++ b/README.md
@@ -272,7 +272,9 @@ Defines whether Reference fields should be resolved using composition.
 
 ```js
 // Example
-api.withComposition();
+api.withComposition(); 
+api.withComposition(true); // same as above
+api.withComposition(false);
 ```
 
 ### Other methods

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ api.in('users')
    .delete();
 ```
 
-#### `.find()`
+#### `.find(options)`
 
 Returns a list of documents.
 
@@ -93,6 +93,11 @@ api.in('users')
    .useFields(['name', 'age'])
    .find();
 ```
+
+`options` is one of the following:
+
+- `extractResults` (Boolean): Selects whether just the results array should be returned, rather than the entire API response.
+- `extractMetadata` (Boolean): Selects whether just the metadata object should be returned, rather than the entire API response.
 
 #### `.map(callback)`
 
@@ -262,15 +267,6 @@ api.where({name: 'John Doe'});
 ```
 
 ### Other methods
-
-#### `.extractResults()`
-
-Selects whether the entire API response should be returned (`false`) or just the results array (`true`). Defaults to `false`.
-
-```js
-// Example
-api.extractResults();
-```
 
 #### `.in(collection)`
 

--- a/README.md
+++ b/README.md
@@ -266,6 +266,15 @@ Filters documents using a MongoDB query object or a Aggregation Pipeline array. 
 api.where({name: 'John Doe'});
 ```
 
+#### `.withComposition(value)`
+
+Defines whether Reference fields should be resolved using composition.
+
+```js
+// Example
+api.withComposition();
+```
+
 ### Other methods
 
 #### `.in(collection)`

--- a/index.js
+++ b/index.js
@@ -234,7 +234,6 @@ DadiAPI.prototype.in = function (collection) {
  * @api public
  */
 DadiAPI.prototype.get = function () {
-  console.log('** URL:', this._buildURL({useParams: true}));
   return passport(this.passportOptions, request).then((function (request) {
     return request({
       json: true,

--- a/index.js
+++ b/index.js
@@ -562,7 +562,7 @@ DadiAPI.prototype.whereFieldIsOneOf = function (field, matches) {
 };
 
 /**
- * Toggles composition for Reference fields
+ * Toggles composition for nested documents
  *
  * @param {Boolean} value
  * @return API


### PR DESCRIPTION
This PR changes the way `extractResults` work. It is no longer a method, and is now an option that can be passed to `.find()` — e.g. `.find({extractResults: true})`.

Similarly, `extractMetadata` can be used to extract just the metadata, solving #1.

Additionally, a `.withComposition()` method was added in order to resolve Reference fields.

@mingard @jimlambie let me know your thoughts.