### PR TITLE
Add debug mode and fix limitTo

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -70,7 +70,7 @@ module.exports = function (DadiAPI) {
         params.fields = this.fields;
       }
 
-      if (this.limit) {
+      if (!isNaN(parseInt(this.limit))) {
         params.count = this.limit;
       }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -102,13 +102,19 @@ module.exports = function (DadiAPI) {
    * @api public
    */
   DadiAPI.prototype._get = function () {
+    var uri = this._buildURL({
+      useParams: true
+    });
+
+    if (this.options.debug && console) {
+      console.log('[@dadi/api-wrapper] Querying URI:', decodeURIComponent(uri));
+    }
+
     return passport(this.passportOptions, request).then((function (request) {
       return request({
         json: true,
         method: 'GET',
-        uri: this._buildURL({
-          useParams: true
-        })
+        uri: uri
       });
     }).bind(this));
   };


### PR DESCRIPTION
This PR adds a debug mode, activated by passing `debug: true` in the config object. When active, it will `console.log()` all requests made:

```
[@dadi/api-wrapper] Querying URI: http://api.eb.dev.dadi.technology:80/vjoin/testdb/articles?count=0
```

It also fixes `limitTo()`, which currently ignores the value `0`, when it's actually used by API to represent an unlimited number of records.