### PR TITLE
Add support for custom endpoints and rename map

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,27 @@ This library provides a high-level abstraction of the REST architecture style, e
 
 ## Methods
 
-Each query consists of a series of chained methods to form the request, always terminated by an operation method. There are 5 terminating operations that return a Promise with the result of one or more requests to the database: [`create()`](#create), [`delete()`](#delete), [`find()`](#find), [`map()`](#map) and [`update()`](#update).
+Each query consists of a series of chained methods to form the request, always terminated by an operation method. There are 5 terminating operations that return a Promise with the result of one or more requests to the database: [`create()`](#create), [`delete()`](#delete), [`find()`](#find), [`apply()`](#apply) and [`update()`](#update).
 
 These operations (with the exception of `create()`) can make use of a series of [filtering methods](#filters) to create the desired subset of documents to operate on.
 
 ### Operations
+
+#### `.apply(callback)`
+
+Updates a list of documents with the result of individually applying `callback` to them.
+
+The return value of the callback function should only include the fields that can be updated and not the whole document. If internal fields are returned (e.g. `history` or `apiVersion`) the operation will fail.
+
+```js
+api.in('users')
+   .whereFieldExists('gender')
+   .apply(function (document) {
+      return {
+        name: (document.gender === 'male') ? ('Mr ' + document.name) : ('Mrs ' + document.name)
+      };
+   });
+```
 
 #### `.create()`
 
@@ -119,22 +135,6 @@ Gets collection stats.
 ```js
 api.in('users')
    .getStats();
-```
-
-#### `.map(callback)`
-
-Updates a list of documents with the result of individually applying `callback` to them. Similar in principle to JavaScript's [Array.map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) function.
-
-The return value of the callback function should only include the fields that can be updated and not the whole document. If internal fields are returned (e.g. `history` or `apiVersion`) the operation will fail.
-
-```js
-api.in('users')
-   .whereFieldExists('gender')
-   .map(function (document) {
-      return {
-        name: (document.gender === 'male') ? ('Mr ' + document.name) : ('Mrs ' + document.name)
-      };
-   });
 ```
 
 #### `.setConfig()`

--- a/README.md
+++ b/README.md
@@ -354,6 +354,15 @@ api.withComposition(false);
 
 ### Other methods
 
+#### `.fromEndpoint(endpoint)`
+
+Selects a custom endpoint to use. Please note that unlike collections, custom endpoints do not have a standardised syntax, so it is up to the authors to make sure the endpoint complies with standard DADI API formats, or they will not function as expected.
+
+```js
+// Example
+api.in('users');
+```
+
 #### `.in(collection)`
 
 Selects the collection to use.

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -1,5 +1,18 @@
 module.exports = function (DadiAPI) {
   /**
+   * Select a custom endpoint
+   *
+   * @param {String} endpoint
+   * @return API
+   * @api public
+   */
+  DadiAPI.prototype.fromEndpoint = function (endpoint) {
+    this.endpoint = endpoint;
+
+    return this;
+  };
+
+  /**
    * Select a page
    *
    * @param {Number} page

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -1,18 +1,5 @@
 module.exports = function (DadiAPI) {
   /**
-   * Select a collection
-   *
-   * @param {String} collection
-   * @return API
-   * @api public
-   */
-  DadiAPI.prototype.in = function (collection) {
-    this.collection = collection;
-
-    return this;
-  };
-
-  /**
    * Select a page
    *
    * @param {Number} page
@@ -21,6 +8,19 @@ module.exports = function (DadiAPI) {
    */
   DadiAPI.prototype.goToPage = function (page) {
     this.page = page;
+
+    return this;
+  };
+
+  /**
+   * Select a collection
+   *
+   * @param {String} collection
+   * @return API
+   * @api public
+   */
+  DadiAPI.prototype.in = function (collection) {
+    this.collection = collection;
 
     return this;
   };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -43,12 +43,17 @@ module.exports = function (DadiAPI) {
     url += this.options.uri;
     url += ':' + this.options.port;
 
-    if (this.collection) {
-      url += '/' + ((this.customVersion !== undefined) ? this.customVersion : this.options.version);
-      url += '/' + ((this.customDatabase !== undefined) ? this.customDatabase : this.options.database);
-      url += '/' + this.collection;    
-    } else {
+    if (!this.collection && !this.endpoint) {
       url += '/api';
+    } else {
+      url += '/' + ((this.customVersion !== undefined) ? this.customVersion : this.options.version);
+
+      if (this.collection) {
+        url += '/' + ((this.customDatabase !== undefined) ? this.customDatabase : this.options.database);
+        url += '/' + this.collection;
+      } else {
+        url += '/' + this.endpoint;
+      }
     }
 
     if (options.config) {

--- a/lib/terminators.js
+++ b/lib/terminators.js
@@ -3,6 +3,62 @@ var request = require('request-promise');
 
 module.exports = function (DadiAPI) {
   /**
+   * Apply the callback to the documents affected by the saved
+   * query and update them
+   *
+   * @param {Function} callback
+   * @return API
+   * @api public
+   */
+  DadiAPI.prototype.apply = function (callback) {
+    if (this.collection === undefined) {
+      throw new Error('`apply()` must be used with a collection');
+    }
+
+    if (this.query === undefined) {
+      throw new Error('Unable to find query for apply');
+    }
+
+    if (typeof callback !== 'function') {
+      throw new Error('Invalid callback for apply');
+    }
+
+    var api = this;
+
+    return passport(this.passportOptions, request).then(function (request) {
+      // Getting a list of the affected documents
+      return request({
+        json: true,
+        method: 'GET',
+        uri: api._buildURL({
+          useParams: true
+        })
+      }).then(function (response) {
+        var updateRequests = [];
+        var updatedDocuments = [];
+
+        response.results.forEach(function (document) {
+          newDocument = callback(document);
+
+          // Updating document
+          updateRequests.push(request({
+            body: newDocument,
+            json: true,
+            method: 'PUT',
+            uri: api._buildURL({
+              id: document._id
+            })
+          }));
+        });
+
+        return Promise.all(updateRequests).then(function () {
+          return updatedDocuments;
+        });
+      });
+    });
+  };
+
+  /**
    * Create one or multiple documents
    *
    * @param {Object} documents
@@ -114,58 +170,6 @@ module.exports = function (DadiAPI) {
         uri: this._buildURL({stats: true})
       });
     }).bind(this));
-  };
-
-  /**
-   * Apply the callback to the documents affected by the saved
-   * query and update them
-   *
-   * @param {Function} callback
-   * @return API
-   * @api public
-   */
-  DadiAPI.prototype.map = function (callback) {
-    if (this.query === undefined) {
-      throw new Error('Unable to find query for map');
-    }
-
-    if (typeof callback !== 'function') {
-      throw new Error('Invalid callback for map');
-    }
-
-    var api = this;
-
-    return passport(this.passportOptions, request).then(function (request) {
-      // Getting a list of the affected documents
-      return request({
-        json: true,
-        method: 'GET',
-        uri: api._buildURL({
-          useParams: true
-        })
-      }).then(function (response) {
-        var updateRequests = [];
-        var updatedDocuments = [];
-
-        response.results.forEach(function (document) {
-          newDocument = callback(document);
-
-          // Updating document
-          updateRequests.push(request({
-            body: newDocument,
-            json: true,
-            method: 'PUT',
-            uri: api._buildURL({
-              id: document._id
-            })
-          }));
-        });
-
-        return Promise.all(updateRequests).then(function () {
-          return updatedDocuments;
-        });
-      });
-    });
   };
 
   /**


### PR DESCRIPTION
This PR adds support for custom endpoints, as requested in #11, by adding a `.fromEndpoint()` function that works as an alternative to `.in()`.

*Example:*

```js
api.fromEndpoint('people')
   .whereFieldIsNotEqualTo('age', 50)
   .find()
   .then(function (response) {
     console.log(response);
   });
```

Additionally, it renames the terminator `.map()` to `.apply()`, since the former can mistakenly lead users to believe that it does not alter the source, which it does. For that reason, `apply` seems like a more appropriate name. This is a **breaking change**.

/cc @jimlambie 