### PR TITLE
Add support for multiple sort filters and /count endpoint

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -60,8 +60,8 @@ module.exports = function (DadiAPI) {
    * @api public
    */
   DadiAPI.prototype.sortBy = function (sortField, sortOrder) {
-    this.sortOrder = (sortOrder === 'desc') ? sortOrder : 'asc'
-    this.sortField = sortField
+    this.sort = this.sort || {}
+    this.sort[sortField] = (sortOrder === 'desc') ? -1 : 1
 
     return this
   }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -95,9 +95,8 @@ module.exports = function (DadiAPI) {
         params.includeHistory = this.history
       }
 
-      if (this.sortField) {
-        params.sort = this.sortField
-        params.sortOrder = this.sortOrder
+      if (this.sort) {
+        params.sort = JSON.stringify(this.sort)
       }
 
       if (paramsStr = querystring.stringify(params, {strict: false})) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -64,6 +64,10 @@ module.exports = function (DadiAPI) {
       url += '/stats'
     }
 
+    if (this.count) {
+      url += '/count'
+    }
+
     if (options.useParams) {
       var params = {}
 

--- a/lib/terminators.js
+++ b/lib/terminators.js
@@ -125,15 +125,13 @@ module.exports = function (DadiAPI) {
    * @api public
    */
   DadiAPI.prototype.find = function (options) {
-    options = options || {}
+    if (options && options.extractMetadata) {
+      this.count = true
+    }
 
     return this._get().then(function (response) {
-      if (options.extractResults) {
+      if (options && options.extractResults) {
         return response.results
-      }
-
-      if (options.extractMetadata) {
-        return response.metadata
       }
 
       return response


### PR DESCRIPTION
This PR adds support for:

- **Multiple sort filters**: Currently only one `.sortBy()` filter is supported. With this PR, multiple sort filters can be chained. Example:

  ```js
  api.in('users')
     .sortBy('name')
     .sortBy('age', 'desc')
     .find()
  ```

- **Support for /count endpoint**: The `extractMetadata` property has been repurposed to support the new `/count` endpoint in API. Example:

  ```js
  api.in('users')
     .whereFieldIsEqualTo('age', 50)
     .find({extractMetadata: true})
  ```
 
/cc @jimlambie @mingard 