### PR TITLE
Check for headers object within error response

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -44,13 +44,18 @@ module.exports = function (APIWrapper) {
 
       return authenticatedRequest(options).catch(err => {
         // Check for an expired token and request a new one
-        if (err.response && err.response.headers['www-authenticate'].indexOf('invalid_token') !== -1) {
+        if (err.response &&
+            err.response.headers &&
+            typeof err.response.headers['www-authenticate'] === 'string' &&
+            err.response.headers['www-authenticate'].indexOf('invalid_token') !== -1) {
           this._log(`The request failed due to an invalid bearer token. Requesting a new one...`)
 
           return passport.refreshToken().then(token => {
             return this._processRequest(this.originalRequestObject)
           })
         }
+
+        return Promise.reject(err)
       })
     })
   }

--- a/test/unit/terminators.js
+++ b/test/unit/terminators.js
@@ -164,8 +164,9 @@ describe('Terminators', function (done) {
 
       // Set up the http intercepts - we ask it to return the same document we passed in
       // because that's what'll happen anyway
+      delete documents[0]._id
+      delete documents[1]._id
       var postScope = nock(host).post(post, documents).reply(200, { results: [ fakeResponse.results ] })
-
       return wrapper
       .useVersion('1.0')
       .useDatabase('test')


### PR DESCRIPTION
Currently API wrapper throws an error if the `err.response` object doesn't have a `headers` property. This adds a check for that and returns `err` untouched if it's not an error caused by an expired token.