### PR TITLE
Listen for content-type header in request object

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -23,15 +23,25 @@ module.exports = function (APIWrapper) {
       uri: requestObject.uri.href
     }
 
+    if (
+      requestObject.headers &&
+      requestObject.headers['content-type'] &&
+      requestObject.headers['content-type'] !== 'application/json'
+    ) {
+      options.json = false
+    }
+
     return passport(this.passportOptions, request).then(authenticatedRequest => {
       debug(`Querying URI: ${decodeURIComponent(options.uri)}`)
 
       return authenticatedRequest(options).catch(err => {
         // Check for an expired token and request a new one
-        if (err.response &&
-            err.response.headers &&
-            typeof err.response.headers['www-authenticate'] === 'string' &&
-            err.response.headers['www-authenticate'].indexOf('invalid_token') !== -1) {
+        if (
+          err.response &&
+          err.response.headers &&
+          typeof err.response.headers['www-authenticate'] === 'string' &&
+          err.response.headers['www-authenticate'].indexOf('invalid_token') !== -1
+        ) {
           debug('The request failed due to an invalid bearer token. Requesting a new one...')
 
           return passport.refreshToken().then(token => {


### PR DESCRIPTION
To support https://github.com/dadi/api-wrapper-core/pull/11, this PR makes API wrapper look for the `content-type` header in the request object and, when found and different from `application/json`, disables the JSON mode from `request-promise`. This is required for the new hook endpoints to work.