### PR TITLE
Only URI encode string values in filters

### DIFF
--- a/core/lib/helpers.js
+++ b/core/lib/helpers.js
@@ -198,7 +198,7 @@ module.exports = function (APIWrapper) {
       ) {
         result[key] = this._encodeObjectKeys(object[key])
       } else {
-        result[key] = encodeURIComponent(object[key])
+        result[key] = typeof object[key] === 'string' ? encodeURIComponent(object[key]) : object[key]
       }
 
       return result

--- a/core/test/unit/helpers.js
+++ b/core/test/unit/helpers.js
@@ -279,5 +279,22 @@ describe('Helpers', function (done) {
 
       done()
     })
+
+    it('should not URL encode non-string values', function (done) {
+      wrapper
+        .useVersion('1.0')
+        .useDatabase('test')
+        .in('collectionOne')
+        .whereFieldIsGreaterThan('email', 1000)
+        .useFields(['email'])
+
+      var wrapperUrl = wrapper._buildURL({useParams: true})
+
+      wrapperUrl.should.eql(
+        `http://0.0.0.0:8000/1.0/test/collectionOne?fields={"email":1}&filter={"email":{"$gt":1000}}`
+      )
+
+      done()
+    })
   })
 })


### PR DESCRIPTION
This PR ensures that numbers are not coerced to strings when preparing a filter to be passed to API

Close #54 